### PR TITLE
Removes Sector From Firebase When Deleted

### DIFF
--- a/src/javascripts/components/views/sectorView.js
+++ b/src/javascripts/components/views/sectorView.js
@@ -14,7 +14,7 @@ const sectorView = () => {
     $('.delete').on('click', (e) => {
       e.stopImmediatePropagation();
       $(`#sectors-${e.currentTarget.id.split('__')[1]}`).remove();
-      sectorData.deleteWeapons(e.currentTarget.id.split('__')[1]);
+      sectorData.deleteSector(e.currentTarget.id.split('__')[1]);
     });
   });
 };

--- a/src/javascripts/helpers/data/sectorData.js
+++ b/src/javascripts/helpers/data/sectorData.js
@@ -3,6 +3,8 @@ import apiKeys from '../apiKeys.json';
 
 const baseUrl = apiKeys.firebaseKeys.databaseURL;
 
+const deleteSector = (firebaseKey) => axios.delete(`${baseUrl}/planetarySectors/${firebaseKey}.json`);
+
 const getSingleSector = (sectorFirebaseKey) => new Promise((resolve, reject) => {
   axios
     .get(
@@ -30,4 +32,4 @@ const getAllSectors = () => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export default { getSingleSector, getAllSectors };
+export default { deleteSector, getSingleSector, getAllSectors };


### PR DESCRIPTION
## Description

Created a function to remove a sector from Firebase when it is deleted from the page.

## Related Issue

- #18 

## Motivation and Context

Allows the users to delete Planetary Sectors from the database.

## How Can This Be Tested?

`git fetch origin delete-sector

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
